### PR TITLE
Prevent 'is already declared in file' error on compilation

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,7 +39,7 @@ define php5-fpm::config ( $ensure = 'present', $content = '', $order='500') {
     }
 
     # Cleans up configs not managed by php5-fpm module
-    exec { 'cleanup-pool':
+    exec { "cleanup-pool-$name":
         cwd     => '/etc/php5/fpm/pool.d',
         path    => "/usr/bin:/usr/sbin:/bin",
         command => "find -name '[^0-9]*.conf' -exec rm {} +",


### PR DESCRIPTION
Hi Benoit,

without the patch I got:

err: Could not retrieve catalog from remote server: Error 400 on SERVER: Duplicate declaration: Exec[cleanup-pool] is already declared in file /etc/puppet/modules/php5-fpm/manifests/config.pp at line 49; cannot redeclare at /etc/puppet/modules/php5-fpm/manifests/config.pp:49 on node

cheers
amette
